### PR TITLE
Support multi-opponent bargaining games with random draws

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # bargaining-app
+
+A lightweight browser-based simulation of a four-round bargaining game with discounted payoffs. You now play as Player 1 and can rotate through any number of AI opponents to decide how three types of items are divided. Every game draws fresh private values and outside options for every participant from the specified uniform distributions, so no two negotiations share the same incentives.
+
+## Getting started
+
+This project is implemented with vanilla HTML, CSS, and JavaScript. No build step is required.
+
+1. Start a static web server in the repository directory, for example:
+
+   ```bash
+   python -m http.server 8000
+   ```
+
+2. Open `http://localhost:8000` in your browser to launch the game.
+
+3. Use the form to propose offers, accept counteroffers, or walk away. The negotiation lasts at most four rounds and applies a 0.95 discount factor each round.
+
+4. Add more opponents from the sidebar to spin up additional private-value agents. Switching the opponent or starting a new game rerolls everyone's values and outside offers according to the 1–100 uniform distribution (and 1–total-value for outside offers), so you can explore many matchups quickly.
+
+After each game the interface reveals the opponent's private valuations and outside offer so you can analyse the outcome and adjust your strategy for the next run.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,537 @@
+const TOTAL_ROUNDS = 4;
+const DISCOUNT = 0.95;
+const VALUE_RANGE = { min: 1, max: 100 };
+const ITEMS = [
+  { name: "Item 1", total: 7 },
+  { name: "Item 2", total: 4 },
+  { name: "Item 3", total: 1 },
+];
+const TOTAL_ITEM_COUNTS = ITEMS.map((item) => item.total);
+
+document.addEventListener("DOMContentLoaded", () => {
+  const roundEl = document.getElementById("round");
+  const turnEl = document.getElementById("turn");
+  const statusMessageEl = document.getElementById("status-message");
+  const historyListEl = document.getElementById("history-list");
+  const currentOfferEl = document.getElementById("current-offer");
+  const summaryEl = document.getElementById("summary");
+  const player1ValuesEl = document.getElementById("player1-values");
+  const player1OutsideEl = document.getElementById("player1-outside");
+  const player2Card = document.getElementById("player2-card");
+  const player2ValuesEl = document.getElementById("player2-values");
+  const player2OutsideEl = document.getElementById("player2-outside");
+  const offerForm = document.getElementById("offer-form");
+  const walkAwayBtn = document.getElementById("walk-away");
+  const acceptBtn = document.getElementById("accept-offer");
+  const submitOfferBtn = document.getElementById("submit-offer");
+  const newGameBtn = document.getElementById("new-game");
+  const opponentSelect = document.getElementById("opponent-select");
+  const addOpponentBtn = document.getElementById("add-opponent");
+  const opponentLabelEl = document.getElementById("opponent-label");
+  const activeOpponentNameEl = document.getElementById("active-opponent-name");
+  const opponentInfoHeadingEl = document.getElementById("opponent-info-heading");
+
+  const offerInputs = ITEMS.map((item, index) => {
+    const input = document.getElementById(`offer-item-${index + 1}`);
+    input.max = item.total;
+    return input;
+  });
+
+  const session = {
+    opponents: [],
+    activeOpponentIndex: 0,
+    nextOpponentNumber: 1,
+  };
+
+  let state = null;
+
+  initializeSession();
+
+  offerForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (state.finished || state.turn !== "P1") return;
+
+    const offer = offerInputs.map((input) => parseInt(input.value, 10) || 0);
+    if (!isValidOffer(offer)) {
+      showStatus(
+        "Offer must use whole numbers between 0 and the available quantity of each item.",
+        true
+      );
+      return;
+    }
+
+    const currentOffer = {
+      from: "P1",
+      to: "P2",
+      quantities: offer,
+    };
+
+    state.currentOffer = currentOffer;
+    logHistory(`Player 1 offers ${formatQuantities(offer)} to ${state.opponent.name}.`);
+    showStatus(`Waiting for ${state.opponent.name}'s response...`);
+    state.turn = "P2";
+    updateUI();
+
+    window.setTimeout(() => {
+      opponentResponse();
+    }, 600);
+  });
+
+  walkAwayBtn.addEventListener("click", () => {
+    if (state.finished) return;
+    if (state.turn === "P1") {
+      concludeWithWalk("Player 1");
+    } else if (state.turn === "P2") {
+      concludeWithWalk(state.opponent.name);
+    }
+  });
+
+  acceptBtn.addEventListener("click", () => {
+    if (state.finished || state.turn !== "P1") return;
+    if (!state.currentOffer || state.currentOffer.from !== "P2") return;
+    concludeWithDeal(state.currentOffer, state.round);
+  });
+
+  newGameBtn.addEventListener("click", () => {
+    startNewGame();
+  });
+
+  addOpponentBtn.addEventListener("click", () => {
+    addOpponent();
+    renderOpponentOptions();
+    startNewGame();
+  });
+
+  opponentSelect.addEventListener("change", (event) => {
+    const index = Number.parseInt(event.target.value, 10);
+    if (Number.isNaN(index) || !session.opponents[index]) {
+      return;
+    }
+    session.activeOpponentIndex = index;
+    startNewGame();
+  });
+
+  function initializeSession() {
+    if (session.opponents.length === 0) {
+      addOpponent();
+    }
+    renderOpponentOptions();
+    startNewGame();
+  }
+
+  function addOpponent() {
+    const opponentName = `Opponent ${session.nextOpponentNumber}`;
+    session.nextOpponentNumber += 1;
+    const values = generateValues();
+    const opponent = {
+      name: opponentName,
+      values,
+      outside: drawOutside(values),
+    };
+    session.opponents.push(opponent);
+    session.activeOpponentIndex = session.opponents.length - 1;
+    return opponent;
+  }
+
+  function startNewGame() {
+    const player1 = createPlayer1();
+    const opponent = rerollActiveOpponent();
+    state = createInitialState(player1, opponent);
+    renderPlayer1Info();
+    resetUI();
+    state.statusMessage = `Make an opening offer to ${state.opponent.name} or walk away.`;
+    state.statusIsError = false;
+    updateUI();
+  }
+
+  function rerollActiveOpponent() {
+    if (session.opponents.length === 0) {
+      addOpponent();
+    }
+    if (session.activeOpponentIndex < 0 || session.activeOpponentIndex >= session.opponents.length) {
+      session.activeOpponentIndex = 0;
+    }
+    const base = session.opponents[session.activeOpponentIndex];
+    const values = generateValues();
+    const outside = drawOutside(values);
+    const opponent = {
+      ...base,
+      values,
+      outside,
+    };
+    session.opponents[session.activeOpponentIndex] = opponent;
+    return opponent;
+  }
+
+  function renderOpponentOptions() {
+    if (session.opponents.length === 0) {
+      opponentSelect.innerHTML = "";
+      opponentSelect.disabled = true;
+      return;
+    }
+
+    opponentSelect.disabled = false;
+    opponentSelect.innerHTML = session.opponents
+      .map((opponent, index) => `<option value="${index}">${opponent.name}</option>`)
+      .join("");
+    opponentSelect.value = String(session.activeOpponentIndex);
+  }
+
+  function resetUI() {
+    historyListEl.innerHTML = "";
+    summaryEl.innerHTML = "";
+    currentOfferEl.innerHTML = "";
+    player2Card.classList.add("hidden");
+    acceptBtn.disabled = true;
+    statusMessageEl.classList.remove("outcome-fail");
+    offerInputs.forEach((input) => {
+      input.value = "";
+      input.disabled = false;
+    });
+    submitOfferBtn.disabled = false;
+    walkAwayBtn.disabled = false;
+  }
+
+  function renderPlayer1Info() {
+    player1ValuesEl.innerHTML = ITEMS.map(
+      (item, idx) => `<li>${item.name}: <strong>${state.player1.values[idx]}</strong> value per unit</li>`
+    ).join("");
+    player1OutsideEl.textContent = state.player1.outside;
+  }
+
+  function updateUI() {
+    roundEl.textContent = state.round;
+    turnEl.textContent = state.turn === "P1" ? "Player 1" : state.opponent.name;
+    statusMessageEl.textContent = state.statusMessage;
+    statusMessageEl.classList.toggle("outcome-fail", Boolean(state.statusIsError));
+    opponentLabelEl.textContent = state.opponent.name;
+    activeOpponentNameEl.textContent = state.opponent.name;
+    opponentInfoHeadingEl.textContent = `${state.opponent.name} Information`;
+    opponentSelect.value = String(session.activeOpponentIndex);
+
+    if (state.currentOffer) {
+      const { from, quantities } = state.currentOffer;
+      const heading = from === "P1" ? `Current Offer to ${state.opponent.name}` : "Current Offer to You";
+      const details = formatQuantities(quantities);
+      const offerValueP1 = computeValue(getShareFor("P1"), state.player1.values);
+      const offerValueP2 = computeValue(getShareFor("P2"), state.opponent.values);
+
+      currentOfferEl.innerHTML = `
+        <h3>${heading}</h3>
+        <p>${from === "P1" ? "You" : state.opponent.name} are offering ${details}.</p>
+        <p>Player 1 value if accepted now: <strong>${offerValueP1.toFixed(2)}</strong></p>
+        <p>${state.opponent.name} value if accepted now: <strong>${offerValueP2.toFixed(2)}</strong></p>
+      `;
+    } else {
+      currentOfferEl.innerHTML = "";
+    }
+
+    acceptBtn.disabled =
+      !state.currentOffer ||
+      state.currentOffer.from !== "P2" ||
+      state.finished ||
+      state.turn !== "P1";
+
+    if (state.finished) {
+      player2Card.classList.remove("hidden");
+      player2ValuesEl.innerHTML = ITEMS.map(
+        (item, idx) => `<li>${item.name}: <strong>${state.opponent.values[idx]}</strong> value per unit</li>`
+      ).join("");
+      player2OutsideEl.textContent = state.opponent.outside;
+    }
+  }
+
+  function getShareFor(player) {
+    if (!state.currentOffer) return TOTAL_ITEM_COUNTS.slice();
+
+    const offer = state.currentOffer.quantities;
+    if (state.currentOffer.from === "P1") {
+      if (player === "P1") {
+        return ITEMS.map((item, idx) => item.total - offer[idx]);
+      }
+      return offer.slice();
+    }
+
+    if (player === "P1") {
+      return offer.slice();
+    }
+    return ITEMS.map((item, idx) => item.total - offer[idx]);
+  }
+
+  function logHistory(message) {
+    const entry = document.createElement("li");
+    entry.textContent = message;
+    historyListEl.prepend(entry);
+  }
+
+  function showStatus(message, isError = false) {
+    state.statusMessage = message;
+    state.statusIsError = isError;
+    statusMessageEl.textContent = message;
+    statusMessageEl.classList.toggle("outcome-fail", Boolean(isError));
+  }
+
+  function isValidOffer(offer) {
+    return offer.every((value, idx) => {
+      const quantity = Number.isFinite(value) ? value : -1;
+      if (!Number.isInteger(quantity) || quantity < 0) {
+        return false;
+      }
+      return quantity <= ITEMS[idx].total;
+    });
+  }
+
+  function computeValue(quantities, values) {
+    return quantities.reduce((sum, qty, idx) => sum + qty * values[idx], 0);
+  }
+
+  function formatQuantities(quantities) {
+    return `${quantities[0]} × Item 1, ${quantities[1]} × Item 2, ${quantities[2]} × Item 3`;
+  }
+
+  function createInitialState(player1, opponent) {
+    return {
+      round: 1,
+      turn: "P1",
+      statusMessage: "",
+      statusIsError: false,
+      currentOffer: null,
+      finished: false,
+      outcome: null,
+      player1,
+      opponent,
+    };
+  }
+
+  function concludeWithDeal(offer, round) {
+    const discountFactor = Math.pow(DISCOUNT, round - 1);
+    const player1Share = getShareFor("P1");
+    const opponentShare = getShareFor("P2");
+    const player1Value = computeValue(player1Share, state.player1.values);
+    const opponentValue = computeValue(opponentShare, state.opponent.values);
+
+    const player1Discounted = player1Value * discountFactor;
+    const opponentDiscounted = opponentValue * discountFactor;
+
+    state.finished = true;
+    state.outcome = {
+      type: "deal",
+      round,
+      offer,
+      player1Value,
+      opponentValue,
+      player1Discounted,
+      opponentDiscounted,
+    };
+
+    logHistory(`Deal reached with ${state.opponent.name} in round ${round}.`);
+    showStatus("Deal reached!", false);
+    renderSummary();
+    disableInputs();
+    updateUI();
+  }
+
+  function concludeWithWalk(player) {
+    const round = state.round;
+    const discountFactor = Math.pow(DISCOUNT, round - 1);
+    const player1Discounted = state.player1.outside * discountFactor;
+    const opponentDiscounted = state.opponent.outside * discountFactor;
+
+    state.finished = true;
+    state.outcome = {
+      type: "walk",
+      by: player,
+      round,
+      player1Discounted,
+      opponentDiscounted,
+    };
+
+    logHistory(`${player} walks away in round ${round}.`);
+    showStatus(`${player} walked away.`, true);
+    renderSummary();
+    disableInputs();
+    updateUI();
+  }
+
+  function disableInputs() {
+    offerInputs.forEach((input) => (input.disabled = true));
+    submitOfferBtn.disabled = true;
+    walkAwayBtn.disabled = true;
+    acceptBtn.disabled = true;
+  }
+
+  function renderSummary() {
+    if (!state.outcome) return;
+
+    const round = state.outcome.round;
+    const discountFactor = Math.pow(DISCOUNT, round - 1).toFixed(4);
+
+    if (state.outcome.type === "deal") {
+      const player1Share = getShareFor("P1");
+      const opponentShare = getShareFor("P2");
+      summaryEl.innerHTML = `
+        <h2>Outcome</h2>
+        <p class="outcome-success">Deal reached in round ${round} (discount factor ${discountFactor}).</p>
+        <table class="summary-table">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Player 1</th>
+              <th>${state.opponent.name}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Units received</th>
+              <td>${formatQuantities(player1Share)}</td>
+              <td>${formatQuantities(opponentShare)}</td>
+            </tr>
+            <tr>
+              <th>Undiscounted value</th>
+              <td>${state.outcome.player1Value.toFixed(2)}</td>
+              <td>${state.outcome.opponentValue.toFixed(2)}</td>
+            </tr>
+            <tr>
+              <th>Discounted payoff</th>
+              <td>${state.outcome.player1Discounted.toFixed(2)}</td>
+              <td>${state.outcome.opponentDiscounted.toFixed(2)}</td>
+            </tr>
+          </tbody>
+        </table>
+      `;
+    } else {
+      summaryEl.innerHTML = `
+        <h2>Outcome</h2>
+        <p class="outcome-fail">${state.outcome.by} walked away in round ${round} (discount factor ${discountFactor}).</p>
+        <p>Discounted payoffs:</p>
+        <ul>
+          <li>Player 1: ${state.outcome.player1Discounted.toFixed(2)} (outside offer)</li>
+          <li>${state.opponent.name}: ${state.outcome.opponentDiscounted.toFixed(2)} (outside offer)</li>
+        </ul>
+      `;
+    }
+  }
+
+  function opponentResponse() {
+    if (state.finished || state.turn !== "P2") return;
+
+    if (!state.currentOffer || state.currentOffer.from !== "P1") {
+      state.turn = "P1";
+      showStatus("It's your turn.");
+      updateUI();
+      return;
+    }
+
+    const offer = state.currentOffer.quantities;
+    const opponentValue = computeValue(offer, state.opponent.values);
+    const discountedOfferValue = opponentValue * Math.pow(DISCOUNT, state.round - 1);
+    const discountedOutside = state.opponent.outside * Math.pow(DISCOUNT, state.round - 1);
+
+    if (discountedOfferValue >= discountedOutside) {
+      logHistory(`${state.opponent.name} accepts your offer.`);
+      concludeWithDeal(state.currentOffer, state.round);
+      return;
+    }
+
+    if (state.round === TOTAL_ROUNDS) {
+      concludeWithWalk(state.opponent.name);
+      return;
+    }
+
+    const counter = computeOpponentCounterOffer();
+    if (counter) {
+      const opponentShare = ITEMS.map((item, idx) => item.total - counter[idx]);
+      const counterValue = computeValue(opponentShare, state.opponent.values);
+      const discountedCounterValue = counterValue * Math.pow(DISCOUNT, state.round - 1);
+      if (discountedCounterValue < discountedOutside) {
+        concludeWithWalk(state.opponent.name);
+        return;
+      }
+
+      state.currentOffer = {
+        from: "P2",
+        to: "P1",
+        quantities: counter,
+      };
+      logHistory(`${state.opponent.name} counters by offering you ${formatQuantities(counter)}.`);
+      state.turn = "P1";
+      showStatus(`${state.opponent.name} made a counteroffer. You may accept, counter, or walk away.`);
+      advanceRound();
+      updateUI();
+    } else {
+      concludeWithWalk(state.opponent.name);
+    }
+  }
+
+  function advanceRound() {
+    if (state.round < TOTAL_ROUNDS) {
+      state.round += 1;
+    }
+  }
+
+  function computeOpponentCounterOffer() {
+    const threshold = state.player1.outside;
+    let bestOffer = null;
+    let bestOpponentValue = -Infinity;
+
+    for (let item1 = 0; item1 <= ITEMS[0].total; item1 += 1) {
+      for (let item2 = 0; item2 <= ITEMS[1].total; item2 += 1) {
+        for (let item3 = 0; item3 <= ITEMS[2].total; item3 += 1) {
+          const offer = [item1, item2, item3];
+          const player1Value = computeValue(offer, state.player1.values);
+          if (player1Value < threshold * 0.85) {
+            continue;
+          }
+          const opponentShare = ITEMS.map((item, idx) => item.total - offer[idx]);
+          const opponentValue = computeValue(opponentShare, state.opponent.values);
+          if (opponentValue > bestOpponentValue) {
+            bestOpponentValue = opponentValue;
+            bestOffer = offer;
+          }
+        }
+      }
+    }
+
+    if (!bestOffer) {
+      for (let item1 = 0; item1 <= ITEMS[0].total; item1 += 1) {
+        for (let item2 = 0; item2 <= ITEMS[1].total; item2 += 1) {
+          for (let item3 = 0; item3 <= ITEMS[2].total; item3 += 1) {
+            const offer = [item1, item2, item3];
+            const opponentShare = ITEMS.map((item, idx) => item.total - offer[idx]);
+            const opponentValue = computeValue(opponentShare, state.opponent.values);
+            if (opponentValue > bestOpponentValue) {
+              bestOpponentValue = opponentValue;
+              bestOffer = offer;
+            }
+          }
+        }
+      }
+    }
+
+    return bestOffer;
+  }
+
+  function randomInt(min, max) {
+    const low = Math.ceil(min);
+    const high = Math.floor(max);
+    return Math.floor(Math.random() * (high - low + 1)) + low;
+  }
+
+  function generateValues() {
+    return ITEMS.map(() => randomInt(VALUE_RANGE.min, VALUE_RANGE.max));
+  }
+
+  function drawOutside(values) {
+    const totalValue = computeValue(TOTAL_ITEM_COUNTS, values);
+    return randomInt(1, Math.max(1, Math.round(totalValue)));
+  }
+
+  function createPlayer1() {
+    const values = generateValues();
+    return {
+      name: "Player 1",
+      values,
+      outside: drawOutside(values),
+    };
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bargaining Game</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Discounted Bargaining Game</h1>
+    <p>Negotiate fair splits across multiple private-value opponents before the 4 rounds expire.</p>
+  </header>
+
+  <main>
+    <section class="info-panel">
+      <div class="card">
+        <h2>Game Parameters</h2>
+        <ul>
+          <li>Total rounds: <strong>4</strong></li>
+          <li>Discount rate: <strong>0.95</strong></li>
+          <li>Items available: 7 × Item 1, 4 × Item 2, 1 × Item 3</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h2>Opponents</h2>
+        <label class="select-label">Current matchup
+          <select id="opponent-select"></select>
+        </label>
+        <button type="button" class="secondary" id="add-opponent">Add Another Opponent</button>
+        <p class="note">Each opponent draws fresh private values and an outside offer every game.</p>
+      </div>
+      <div class="card">
+        <h2>Your Private Values</h2>
+        <ul id="player1-values"></ul>
+        <p>Your outside offer: <strong id="player1-outside"></strong></p>
+      </div>
+      <div class="card hidden" id="player2-card">
+        <h2 id="opponent-info-heading">Opponent Information</h2>
+        <p class="note">Hidden during negotiation. Revealed when the game ends.</p>
+        <ul id="player2-values"></ul>
+        <p>Outside offer: <strong id="player2-outside"></strong></p>
+      </div>
+    </section>
+
+    <section class="game-panel">
+      <div class="status-bar">
+        <div>Round: <span id="round">1</span> / 4</div>
+        <div>Turn: <span id="turn">Player 1</span></div>
+        <div>Opponent: <span id="active-opponent-name">Opponent</span></div>
+        <div class="status-message" id="status-message">Make an opening offer or walk away.</div>
+      </div>
+
+      <div class="offer-section">
+        <h2>Your Action</h2>
+        <form id="offer-form">
+          <p class="instruction">Enter how many units you offer to <span id="opponent-label">the opponent</span>.</p>
+          <div class="input-grid">
+            <label>Item 1
+              <input type="number" min="0" step="1" id="offer-item-1" required />
+            </label>
+            <label>Item 2
+              <input type="number" min="0" step="1" id="offer-item-2" required />
+            </label>
+            <label>Item 3
+              <input type="number" min="0" step="1" id="offer-item-3" required />
+            </label>
+          </div>
+          <div class="button-row">
+            <button type="submit" class="primary" id="submit-offer">Submit Offer</button>
+            <button type="button" id="walk-away" class="secondary">Walk Away</button>
+            <button type="button" id="accept-offer" class="secondary" disabled>Accept Current Offer</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="current-offer" id="current-offer"></div>
+
+      <div class="history">
+        <h2>Negotiation History</h2>
+        <ul id="history-list"></ul>
+      </div>
+
+      <div class="summary" id="summary"></div>
+
+      <div class="controls">
+        <button type="button" id="new-game" class="primary">Start New Game</button>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>Built for exploring strategic bargaining with private values and discounted rounds.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,257 @@
+:root {
+  --bg: #f5f7fb;
+  --primary: #3357ff;
+  --primary-dark: #1f36a3;
+  --secondary: #f0f1f6;
+  --text: #1f2430;
+  --muted: #6b7280;
+  --success: #0f9d58;
+  --danger: #d93025;
+  --shadow: 0 18px 32px rgba(31, 36, 48, 0.1);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+header,
+footer {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  background: white;
+  box-shadow: var(--shadow);
+  margin-bottom: 1.5rem;
+}
+
+header h1 {
+  margin: 0 0 0.4rem;
+  font-size: 2rem;
+}
+
+main {
+  display: grid;
+  grid-template-columns: minmax(280px, 320px) 1fr;
+  gap: 1.5rem;
+  padding: 0 1.5rem 3rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.info-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card {
+  background: white;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+}
+
+.card ul {
+  padding-left: 1.2rem;
+  margin: 0.5rem 0 0;
+}
+
+.card li {
+  margin-bottom: 0.4rem;
+}
+
+.note {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.game-panel {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.status-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--secondary);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  font-weight: 600;
+}
+
+.status-message {
+  flex-basis: 100%;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.offer-section form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.input-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+label {
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+input[type="number"] {
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+}
+
+select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+  background-color: white;
+}
+
+.select-label {
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+button.primary {
+  background: var(--primary);
+  color: white;
+  box-shadow: var(--shadow);
+}
+
+button.primary:hover:not(:disabled) {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+button.secondary {
+  background: white;
+  color: var(--text);
+  border: 1px solid #d1d5db;
+}
+
+button.secondary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.current-offer,
+.summary {
+  background: var(--secondary);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+}
+
+.current-offer h3,
+.summary h2 {
+  margin: 0 0 0.6rem;
+}
+
+.history ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.history li {
+  padding: 0.75rem 1rem;
+  background: var(--secondary);
+  border-radius: 10px;
+  margin-bottom: 0.6rem;
+  font-size: 0.95rem;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.75rem;
+}
+
+.summary-table th,
+.summary-table td {
+  border: 1px solid #d1d5db;
+  padding: 0.5rem 0.75rem;
+  text-align: center;
+}
+
+.summary-table th {
+  background: white;
+}
+
+.outcome-success {
+  color: var(--success);
+}
+
+.outcome-fail {
+  color: var(--danger);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .status-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add an opponent roster UI so you can switch between or add multiple negotiating partners
- refactor the game logic to reroll every player's private values and outside offers each time a game starts
- refresh styling and docs to reflect multi-opponent play and automatic random draws each match

## Testing
- not run (static web app)


------
https://chatgpt.com/codex/tasks/task_e_68de9fb2266c832e8c63cfedd7ed426b