### PR TITLE
Persist completed games to history file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data/game-history.json

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ WebSocket server.
 5. Take turns making offers, accepting counteroffers, or walking away. After each game, the interface reveals both
    players' private valuations and outside offers so you can analyse the outcome before starting a fresh game.
 
+### Saved game history
+
+Every completed negotiation (including walk-aways and disconnects) is appended to `data/game-history.json` on the
+server. The file contains the full public timeline of offers, the revealed private information, and the final outcome
+so you can review past matches or import them into other tools for analysis.
+
 ## Game rules
 
 - The negotiation lasts at most four rounds with a `0.95` discount applied each round.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,1 @@
+game-history.json


### PR DESCRIPTION
## Summary
- add server-side persistence that appends finished games, walk-aways, and disconnects to `data/game-history.json`
- capture configuration, public history, and revealed private info in each stored record for later analysis
- document the saved history location and keep generated artifacts out of version control

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e36331cffc832eb69a562d6343493e